### PR TITLE
Value classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
-crossScalaVersions := Seq("2.10.6", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 val commonCommonSettings = Seq(
   organization := "io.github.netvl.picopickle",
   version := "0.2.1",
-  scalaVersion := "2.11.7",
+  scalaVersion := "2.11.8",
 
   autoAPIMappings := true
 )

--- a/core/src/main/scala/io/github/netvl/picopickle/ValueClasses.scala
+++ b/core/src/main/scala/io/github/netvl/picopickle/ValueClasses.scala
@@ -1,0 +1,37 @@
+package io.github.netvl.picopickle
+
+import io.github.netvl.picopickle.backends.collections.CollectionsPickler
+import shapeless._
+import shapeless.ops.hlist.IsHCons
+
+trait ValueClassReaders { this: TypesComponent ⇒
+  implicit def valueClassReader[
+    ValueClass <: AnyVal,
+    VCAsHList <: HList,
+    Value
+  ](implicit gen: Generic.Aux[ValueClass, VCAsHList],
+    isHCons: IsHCons.Aux[VCAsHList, Value, HNil],
+    valueReader: Reader[Value],
+    eqv: (Value :: HNil) =:= VCAsHList): Reader[ValueClass] =
+    valueReader.andThen { value ⇒
+      gen.from(value :: HNil)
+    }
+}
+
+trait ValueClassWriters { this: TypesComponent ⇒
+  implicit def valueClassWriter[
+    ValueClass <: AnyVal,
+    VCAsHList <: HList,
+    Value](implicit gen: Generic.Aux[ValueClass, VCAsHList],
+           isHCons: IsHCons.Aux[VCAsHList, Value, HNil],
+           valueWriter: Writer[Value]): Writer[ValueClass] =
+    Writer(t ⇒ valueWriter.write(gen.to(t).head))
+}
+
+/* By default, a value class is pickled like any case class,
+ * i.e. `MyValueClass("someValue")` becomes `Map("value" -> "someValue")`
+ * if you mix in this trait, the above instance gets serialises as "someValue" (no Map)
+ */
+trait ValueClassesReaderWritersComponent extends ValueClassReaders with ValueClassWriters {
+  this: BackendComponent with TypesComponent =>
+}

--- a/core/src/main/scala/io/github/netvl/picopickle/pickler.scala
+++ b/core/src/main/scala/io/github/netvl/picopickle/pickler.scala
@@ -34,7 +34,8 @@ trait DefaultPickler
   with MapPicklingEnabledByDefault
   with TupleReaderWritersComponent
   with ConvertersComponent
-  with TypesComponent {
+  with TypesComponent
+  with ValueClassesReaderWritersComponent {
   this: BackendComponent =>
 
   override def read[T](value: backend.BValue)(implicit r: Reader[T]): T = r.read(value)

--- a/core/src/test/scala/io/github/netvl/picopickle/Fixtures.scala
+++ b/core/src/test/scala/io/github/netvl/picopickle/Fixtures.scala
@@ -57,4 +57,8 @@ object Fixtures {
   object WithVarargs {
     case class A(x: Int, y: String*)
   }
+
+  object ValueClass {
+    case class A(value: String) extends AnyVal
+  }
 }

--- a/project/tests/Pickler.yml
+++ b/project/tests/Pickler.yml
@@ -171,6 +171,14 @@ cases:
         - 'Map("x" -> 10, "y" -> "hi")'
         - '"""{"x":10,"y":"hi"}"""'
         - 'new BsonDocument().append("x", new BsonInt32(10)).append("y", new BsonString("hi"))'
+  - name: value class to an object
+    prepend: |
+      import ValueClass._
+    rw:
+      - - 'A("hi")'
+        - '"hi"'
+        - '""""hi""""'
+        - 'new new BsonString("hi")'
   - name: case object to an empty object
     prepend: |
       import CaseObject._


### PR DESCRIPTION
As discussed in https://github.com/netvl/picopickle/issues/16

I was lazy and made the new value class pickler the default. If no one is using this library yet, why worry about backwards compatibility? :)
Feel free to change that though, I just wasn't sure how to do this nicely in Pickler.yml which generates the tests. 
