### PR TITLE
quick 2.12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-picopickle 0.3.0
+picopickle 0.3.2
 ================
 
 picopickle is a serialization library for Scala. Its main features are:
@@ -61,10 +61,10 @@ The library is published to the Maven central, so you can just add the following
 to your `build.sbt` file in order to use the core library:
 
 ```scala
-libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-core" % "0.3.0"
+libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-core" % "0.3.2"
 ```
 
-The library is compiled for both 2.10 and 2.11 Scala versions. If you use 2.10, however,
+The library is compiled for Scala versions 2.10, 2.11, 2.12. If you use 2.10, however,
 you will need to add [Macro Paradise] compiler plugin because shapeless macros depend on it:
 
 ```scala
@@ -73,7 +73,7 @@ libraryDependencies += compilerPlugin("org.scalamacros" %% "paradise" % "2.0.1" 
 addCompilerPlugin("org.scalamacros" %% "paradise" % "2.0.1" cross CrossVersion.full)
 ```
 
-Scala 2.11 users do not need this as all relevant macro support is already present in 2.11.
+Scala 2.11/12 users do not need this as all relevant macro support is already present in 2.11/12.
 
   [Macro Paradise]: http://docs.scala-lang.org/overviews/macros/paradise.html
 
@@ -85,7 +85,7 @@ backend, and an additional JSON backend based on [Jawn] parser is available as
 `picopickle-backend-jawn`:
 
 ```scala
-libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-backend-jawn" % "0.3.0"
+libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-backend-jawn" % "0.3.2"
 ```
 
 Jawn backend uses Jawn parser (naturally!) to read JSON strings but it uses custom renderer
@@ -1164,7 +1164,7 @@ picopickle has several "official" backends. One of them, provided by `picopickle
 into a tree of collections. This backend is available immediately with only the `core` dependency:
 
 ```scala
-libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-core" % "0.3.0"
+libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-core" % "0.3.2"
 ```
 
 In this backend the following AST mapping holds:
@@ -1202,7 +1202,7 @@ Another official backend is used for conversion to and from JSON. JSON parsing i
 JSON rendering, however, is custom. This backend is available in `picopickle-backend-jawn`:
 
 ```scala
-libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-backend-jawn" % "0.3.0"
+libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-backend-jawn" % "0.3.2"
 ```
 
 This backend's AST is defined in `io.github.netvl.picopickle.backends.jawn.JsonAst` and consists of several
@@ -1222,7 +1222,7 @@ because it would require a completely different architecture.
 Another official backend is used for conversion to and from BSON AST, as defined by [MongoDB BSON][bson] library.
 
 ```scala
-libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-backend-mongodb-bson" % "0.3.0"
+libraryDependencies += "io.github.netvl.picopickle" %% "picopickle-backend-mongodb-bson" % "0.3.2"
 ```
 
 In this backend the following AST mapping holds:
@@ -1460,6 +1460,10 @@ object Serializers {
 
 <a name="changelog"></a> Changelog
 ----------------------------------
+
+### 0.3.2
+
+* Updated scala to 2.12.3
 
 ### 0.3.0
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
-crossScalaVersions := Seq("2.10.6", "2.11.8")
+crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.3")
 
 val commonCommonSettings = Seq(
   organization := "io.github.netvl.picopickle",
-  version := "0.3.0",
-  scalaVersion := "2.11.8",
+  version := "0.3.2",
+  scalaVersion := "2.12.3",
 
   autoAPIMappings := true
 )

--- a/core/src/main/scala/io/github/netvl/picopickle/objectkeys.scala
+++ b/core/src/main/scala/io/github/netvl/picopickle/objectkeys.scala
@@ -30,7 +30,7 @@ trait ObjectKeyTypesComponent {
   type ObjectKeyReadWriter[T] = ObjectKeyReader[T] with ObjectKeyWriter[T]
 
   object ObjectKeyReadWriter {
-    def apply[T](from: String => T): ObjectKeyReadWriter[T] = apply(_.toString, from)
+    def apply[T](from: String => T): ObjectKeyReadWriter[T] = apply((t: T) => t.toString, from)
 
     def apply[T](to: T => String, from: String => T): ObjectKeyReadWriter[T] = new ObjectKeyReader[T] with ObjectKeyWriter[T] {
       override def write(value: T): String = to(value)

--- a/core/src/test/scala/io/github/netvl/picopickle/ConvertersTestBase.scala
+++ b/core/src/test/scala/io/github/netvl/picopickle/ConvertersTestBase.scala
@@ -4,7 +4,7 @@ import scala.collection.immutable.{TreeMap, TreeSet}
 import scala.collection.mutable
 import shapeless._
 
-import org.scalatest.{FreeSpec, ShouldMatchers}
+import org.scalatest.{FreeSpec, Matchers}
 
 object ConvertersTestBase {
   object ComplexObjects {
@@ -13,7 +13,7 @@ object ConvertersTestBase {
   }
 }
 
-trait ConvertersTestBase extends FreeSpec with ShouldMatchers with DefaultPickler {
+trait ConvertersTestBase extends FreeSpec with Matchers with DefaultPickler {
   this: BackendComponent =>
 
   import backend._

--- a/jawn/src/main/scala/io/github/netvl/picopickle/backends/jawn/ast.scala
+++ b/jawn/src/main/scala/io/github/netvl/picopickle/backends/jawn/ast.scala
@@ -85,10 +85,9 @@ object JawnFacade extends MutableFacade[JsonAst.JsonValue] {
   override def jarray(vs: mutable.Builder[JsonValue, Vector[JsonValue]]): JsonValue =
     JsonArray(vs.result())
 
-  override def jint(s: String): JsonValue = JsonNumber(s.toDouble)
-  override def jnum(s: String): JsonValue = JsonNumber(s.toDouble)
+  override def jnum(s: CharSequence, decIndex: Int, expIndex: Int): JsonValue = JsonNumber(s.toString.toDouble)
 
-  override def jstring(s: String): JsonValue = JsonString(s)
+  override def jstring(s: CharSequence): JsonValue = JsonString(s.toString)
 
   override def jtrue(): JsonValue = JsonTrue
   override def jfalse(): JsonValue = JsonFalse
@@ -103,7 +102,7 @@ private[jawn] trait MutableFacade[J] extends Facade[J] {
   override def singleContext(): FContext[J] = new FContext[J] {
     private var value: J = _
     override def isObj: Boolean = false
-    override def add(s: String): Unit = value = jstring(s)
+    override def add(s: CharSequence): Unit = value = jstring(s)
     override def add(v: J): Unit = value = v
     override def finish: J = value
   }
@@ -112,8 +111,8 @@ private[jawn] trait MutableFacade[J] extends Facade[J] {
     private var key: String = null
     private val builder = Map.newBuilder[String, J]
     override def isObj: Boolean = true
-    override def add(s: String): Unit =
-      if (key == null) key = s
+    override def add(s: CharSequence): Unit =
+      if (key == null) key = s.toString
       else {
         builder += key -> jstring(s)
         key = null
@@ -128,7 +127,7 @@ private[jawn] trait MutableFacade[J] extends Facade[J] {
   override def arrayContext(): FContext[J] = new FContext[J] {
     private val builder = Vector.newBuilder[J]
     override def isObj: Boolean = false
-    override def add(s: String): Unit = builder += jstring(s)
+    override def add(s: CharSequence): Unit = builder += jstring(s)
     override def add(v: J): Unit = builder += v
     override def finish: J = jarray(builder)
   }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,9 +1,9 @@
 object Versions {
-  val shapeless = "2.3.0"
+  val shapeless = "2.3.2"
   val paradise = "2.1.0"
   val macroCompat = "1.1.1"
-  val scalatest = "2.2.6"
-  val jawn = "0.8.4"
+  val scalatest = "3.0.1"
+  val jawn = "0.11.0"
   val mongodbBson = "3.2.2"
 }
 

--- a/project/tests/Pickler.yml
+++ b/project/tests/Pickler.yml
@@ -3,12 +3,12 @@ template: |
   package ${package}
 
   import scala.collection.immutable.ListMap
-  import org.scalatest.{FreeSpec, ShouldMatchers}
+  import org.scalatest.{FreeSpec, Matchers}
   import io.github.netvl.picopickle.ValueClassReaderWritersComponent
   import io.github.netvl.picopickle.Fixtures._
   ${additionalImports}
 
-  class ${name}PicklerTest extends FreeSpec with ShouldMatchers {
+  class ${name}PicklerTest extends FreeSpec with Matchers {
     trait Fixture extends ${picklerClass} {
       def testRW[T: Reader: Writer](t: T, a: ${targetType}): Unit = {
         val s = ${write}(t)


### PR DESCRIPTION
Updated a few library versions. All tests pass. You probably want to verify that the changes in `ast.scala` do what they should, as the facade API appears to have changed. (point of comparison: https://github.com/non/jawn/blob/master/ast/src/main/scala/jawn/ast/JawnFacade.scala#L12-L17)